### PR TITLE
In production mode do not mount host directory into docker /usr/src/a…

### DIFF
--- a/run_docker_production.sh
+++ b/run_docker_production.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 CURRENT_DIR=`pwd`
 
-npm install
-
 echo 'Starting Kaltura broker in production...'
 echo ''
 if [[ "Z$FBF_TOKEN" == 'Z' ]]; then
@@ -20,10 +18,8 @@ echo 'Environment configured.'
 echo ''
 echo 'Connect to: http://localhost:3000'
 
-docker run \
-  --rm \
+docker run -d \
   --name kaltura-broker \
-  -v "$CURRENT_DIR":/usr/src/app \
   -e "KALTURA_SESSION_EXPIRY=$KALTURA_SESSION_EXPIRY" \
   -e "KALTURA_SESSION_PRIVILEGES=$KALTURA_SESSION_PRIVILEGES" \
   -e "KALTURA_SECRET=$KALTURA_SECRET" \


### PR DESCRIPTION
In production mode do not mount host directory into docker /usr/src/app/:
Use image's application files copied during docker build instead.
Use image's installed modules created with 'npm install' during docker build instead.

Remove -ti and -rm options from docker command:
Run docker in detached mode
